### PR TITLE
Fix Frenet-Cartesian roundtrip transformation errors

### DIFF
--- a/matlab/Cart2FRT.m
+++ b/matlab/Cart2FRT.m
@@ -1,38 +1,39 @@
-function [ o_fS, o_fD ] = Cart2FRT(i_fX, i_fY, i_fPsi, i_faRefX, i_faRefY)
+function [ o_fS, o_fD ] = Cart2FRT(i_fX, i_fY, i_faRefX, i_faRefY)
 %Cart2FRT Transform from Cartesian x,y coordinates to Frenet s,d coordinates
-%   Detailed explanation goes here
+%   Given a query point (i_fX, i_fY) and a reference path defined by
+%   (i_faRefX, i_faRefY), compute the Frenet coordinates:
+%     o_fS - arc length along the reference path to the projection point
+%     o_fD - signed lateral offset (positive = left of path direction)
 
-%nNextRefPoint = NextRefPoint(i_fX, i_fY, i_fPsi, i_faRefX, i_faRefY);
+% Step 1: Find the two closest reference points and determine the segment
 [nClosestRefPoint, nClosest2ndRefPoint] = ClosestRefPoint(i_fX, i_fY, i_faRefX, i_faRefY);
 
+% The "next" ref point is the one further along the path
 if (nClosestRefPoint > nClosest2ndRefPoint)
     nNextRefPoint = nClosestRefPoint;
 else
     nNextRefPoint = nClosest2ndRefPoint;
 end
-    
 
 nPrevRefPoint = nNextRefPoint-1;
 if(nNextRefPoint == 1)
-    
-    %nPrevRefPoint  = length(i_faRefX);
     nPrevRefPoint  = 1;
     nNextRefPoint  = 2;
 end
 
+% Step 2: Compute the tangent vector of the segment
 fTangentX = i_faRefX(nNextRefPoint) - i_faRefX(nPrevRefPoint);
 fTangentY = i_faRefY(nNextRefPoint) - i_faRefY(nPrevRefPoint);
 
 %qTangent = quiver(i_faRefX(nPrevRefPoint), i_faRefY(nPrevRefPoint), fTangentX, fTangentY, 0);
 
+% Step 3: Compute vector from previous ref point to query point
 fVecX = i_fX - i_faRefX(nPrevRefPoint);
 fVecY = i_fY - i_faRefY(nPrevRefPoint);
 
 %qVec = quiver(i_faRefX(nPrevRefPoint), i_faRefY(nPrevRefPoint), fVecX, fVecY, 0);
 
-% find the projection of vec onto tangential vector
-%fProjectedVecNorm = (fVecX*fTangentX + fVecY*fTangentY) / ...
-%                  sqrt(fTangentX*fTangentX + fTangentY*fTangentY);
+% Step 4: Project query vector onto the tangent to find the projection point
 fTangentLength = norm([fTangentX, fTangentY]);
 fProjectedVecNorm = dot([fVecX, fVecY], [fTangentX, fTangentY]) / ...
                     fTangentLength;
@@ -41,9 +42,10 @@ fProjectedVecY = fProjectedVecNorm * fTangentY/fTangentLength;
 
 %qProjectedVec = quiver(i_faRefX(nPrevRefPoint), i_faRefY(nPrevRefPoint), fProjectedVecX, fProjectedVecY, 0);
 
+% Step 5: Compute lateral offset d (distance from query to projection)
 o_fD = Distance(fVecX, fVecY, fProjectedVecX, fProjectedVecY);
 
-% Check if d value is positive or negative using the dot product result
+% Determine sign of d using cross product: positive = left of path
 fX1 = i_faRefX(nPrevRefPoint);
 fY1 = i_faRefY(nPrevRefPoint);
 fX2 = i_faRefX(nNextRefPoint);
@@ -54,11 +56,11 @@ nSide = sign(fd);
 if (nSide > 0)
     o_fD = o_fD * -1;
 end
-    
 
-% calculate s value
+% Step 6: Compute arc length s by summing segment lengths up to
+% nPrevRefPoint, then adding the projected distance along the segment
 o_fS = 0;
-for i = 1:nPrevRefPoint
+for i = 1:nPrevRefPoint-1
     o_fS = o_fS + Distance(i_faRefX(i), i_faRefY(i), i_faRefX(i+1),i_faRefY(i+1));
 end
 

--- a/matlab/ClosestRefPoint.m
+++ b/matlab/ClosestRefPoint.m
@@ -1,43 +1,9 @@
 function [o_nClosestRefPoint, o_nClosest2ndRefPoint] = ClosestRefPoint(i_fX, i_fY, i_faRefX, i_faRefY)
-%UNTITLED2 Summary of this function goes here
-%   Detailed explanation goes here
+%ClosestRefPoint Find the two closest reference path points to a query point
 
+[~, SortIdx] = sort(vecnorm([i_fX - i_faRefX; i_fY - i_faRefY]));
+o_nClosestRefPoint = SortIdx(1);
+o_nClosest2ndRefPoint = SortIdx(2);
 
-fClosestLen = inf;
-o_nClosestRefPoint = 1;
-
-for i = 1:length(i_faRefX)
-    fRefX = i_faRefX(i);
-    fRefY = i_faRefY(i);
-    
-    fDist = Distance(i_fX, i_fY, fRefX, fRefY);
-    if(fDist < fClosestLen)
-        
-        fClosestLen = fDist;
-        o_nClosestRefPoint = i;
-    else
-        break;
-    end 
-end
-
-if o_nClosestRefPoint == length(i_faRefX)
-    o_nClosest2ndRefPoint = o_nClosestRefPoint - 1;
-elseif o_nClosestRefPoint == 1
-    o_nClosest2ndRefPoint = o_nClosestRefPoint + 1;
-else
-    fRefXp1 = i_faRefX(o_nClosestRefPoint+1);
-    fRefYp1 = i_faRefY(o_nClosestRefPoint+1);
-    fDistp1 = Distance(i_fX, i_fY, fRefXp1, fRefYp1);
-
-    fRefXm1 = i_faRefX(o_nClosestRefPoint-1);
-    fRefYm1 = i_faRefY(o_nClosestRefPoint-1);
-    fDistm1 = Distance(i_fX, i_fY, fRefXm1, fRefYm1);
-
-    if(fDistm1 < fDistp1)
-        o_nClosest2ndRefPoint = o_nClosestRefPoint - 1;
-    else
-        o_nClosest2ndRefPoint = o_nClosestRefPoint + 1;
-    end
-end
 end
 

--- a/matlab/FRT2Cart.m
+++ b/matlab/FRT2Cart.m
@@ -1,28 +1,34 @@
 function [o_fX, o_fY] = FRT2Cart(i_fS, i_fD, i_faRefRunLength, i_faRefX, i_faRefY)
 %FRT2Cart Transform from Frenet s,d coordinates to Cartesian x,y
-%   Detailed explanation goes here
+%   Given Frenet coordinates (i_fS, i_fD) and a reference path defined by
+%   cumulative arc lengths (i_faRefRunLength) and points (i_faRefX, i_faRefY),
+%   compute the Cartesian position:
+%     o_fX - x coordinate in world frame
+%     o_fY - y coordinate in world frame
 
-    nNextRefPoint = 0;
-
-    while ((i_fS > i_faRefRunLength(nNextRefPoint+1)) && (nNextRefPoint < length(i_faRefRunLength)))
-
-        nNextRefPoint = nNextRefPoint + 1;
+    % Step 1: Find the segment containing arc length s
+    nPrevRefPoint = 1;
+    while ((nPrevRefPoint < length(i_faRefRunLength)) && (i_fS > i_faRefRunLength(nPrevRefPoint+1)))
+        nPrevRefPoint = nPrevRefPoint + 1;
     end
+    nNextRefPoint = nPrevRefPoint + 1;
 
-    nPrevRefPoint = nNextRefPoint-1;
-
+    % Step 2: Compute segment heading
     fHeading = atan2((i_faRefY(nNextRefPoint)-i_faRefY(nPrevRefPoint)), ...
         (i_faRefX(nNextRefPoint)-i_faRefX(nPrevRefPoint)));
-    % The x,y,s along the segment
-    fSegmentS = i_fS - i_faRefRunLength(nPrevRefPoint);
 
+    % Step 3: Find the (x,y) point along the segment at arc length s
+    % fSegmentS is the remaining arc length within this segment
+    fSegmentS = i_fS - i_faRefRunLength(nPrevRefPoint);
     fSegmentX = i_faRefX(nPrevRefPoint) + fSegmentS * cos(fHeading);
     fSegmentY = i_faRefY(nPrevRefPoint) + fSegmentS * sin(fHeading);
 
-    fPerpendicularHeading = fHeading - pi/2;
-
-    o_fX = fSegmentX + i_fD * cos(fPerpendicularHeading);
-    o_fY = fSegmentY - i_fD * sin(fPerpendicularHeading);
+    % Step 4: Offset by d in the left-normal direction
+    % Rotate heading by +pi/2 (counter-clockwise) to get the left-normal
+    % cos(heading + pi/2) = -sin(heading), sin(heading + pi/2) = cos(heading)
+    fLeftNormalHeading = fHeading + pi/2;
+    o_fX = fSegmentX + i_fD * cos(fLeftNormalHeading);  % = segX - d*sin(heading)
+    o_fY = fSegmentY + i_fD * sin(fLeftNormalHeading);  % = segY + d*cos(heading)
 
 end
 

--- a/matlab/transformation.m
+++ b/matlab/transformation.m
@@ -93,7 +93,7 @@ for i = 1:length(faObjects)
     fObjX = faObjects(i,1);
     fObjY = faObjects(i,2);
     
-    [fObjS, fObjD] = Cart2FRT(fObjX, fObjY, 0, faRefX, faRefY);
+    [fObjS, fObjD] = Cart2FRT(fObjX, fObjY, faRefX, faRefY);
     
     hof = plot(fObjS, fObjD, 'kx', 'DisplayName', 'Objects');
     
@@ -107,7 +107,7 @@ for i = 1:length(faObjects)
         fObjX = faObj(j,1);
         fObjY = faObj(j,2);
     
-        [fObjS, fObjD] = Cart2FRT(fObjX, fObjY, 0, faRefX, faRefY);
+        [fObjS, fObjD] = Cart2FRT(fObjX, fObjY, faRefX, faRefY);
         faObjS(j) = fObjS;
         faObjD(j) = fObjD;
         
@@ -123,7 +123,7 @@ set(hl, 'Interpreter', 'latex');
 fObjX = faObjects(1,1)
 fObjY = faObjects(1,2)
 
-[fObjS, fObjD] = Cart2FRT(fObjX, fObjY, 0, faRefX, faRefY);
+[fObjS, fObjD] = Cart2FRT(fObjX, fObjY, faRefX, faRefY);
 
 [fX, fY] = FRT2Cart(fObjS, fObjD, faRefRunLength, faRefX, faRefY)
 


### PR DESCRIPTION
## Summary

Fix four bugs causing Cart2FRT -> FRT2Cart roundtrip to not return the original point:

1. **FRT2Cart**: fix x-component sign (`+` -> `-`) so perpendicular offset uses the left-normal (`-sin heading`, `+cos heading`) consistently. Replaced confusing right-normal (`heading - pi/2`) with left-normal (`heading + pi/2`).

2. **FRT2Cart**: fix while loop that started at index 0, giving invalid MATLAB index `nPrevRefPoint=0`.

3. **Cart2FRT**: fix s accumulation loop bound - loop iterated one segment too far (`1:nPrevRefPoint` instead of `1:nPrevRefPoint-1`), overcounting the arc length to the projection point.

4. **ClosestRefPoint**: replace early-break loop with vecnorm-based sort to avoid missing the true closest point on curved paths.

Also remove unused `i_fPsi` parameter from Cart2FRT signature, update call sites in transformation.m, and add docstrings and step comments.

Closes #10
