### PR TITLE
Fix and reorganize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Path planning in frenet coordinates:
 
 1. **Determine the trajectory start state** $\[x_1,x_2,\theta,\kappa,v,a\](0)$
 The trajectory start state is obtained by evaluating the previously calculated trajectory
-at the prospective start state (low-level-stabilization). 
-At system initialization and after reinitialization, the current vehicle 
+at the prospective start state (low-level-stabilization).
+At system initialization and after reinitialization, the current vehicle
 position is used instead (high-level-stabilization).
 2. **Selection of the lateral mode**
 Depending on the velocity $v$ the time based ($d(t)$) or running length / arc length based ($d(s)$)
 lateral planning mode is activated. By projecting the start state onto the reference curve the
-the longitudinal start position $s(0)$ is determined. The frenet state vector 
+the longitudinal start position $s(0)$ is determined. The frenet state vector
 $\[s,\dot{s},\ddot{s},d,d',d''\](0)$ can be determined using the frenet transformation.
 For the time based lateral planning mode, $\[\dot{d}, \ddot{d}\](0)$ need to be calculated.
 3. **Generating the laterl and longitudinal trajectories**
-Trajectories including their costs are generated for the lateral (mode dependent) 
+Trajectories including their costs are generated for the lateral (mode dependent)
 as well as the longitudinal motion (velocity keeping, vehicle following / distance keeping) in the frenet space.
 In this stage, trajectories with high lateral accelerations with respect to the reference
 path can be neglected to improve the computational performance.
@@ -34,22 +34,22 @@ Summing the partial costs of lateral and longitduinal costs using
 $J(d(t),s(t)) = J_d(d(t)) + k_s \cdot J_s(s(t))$, for all active longidtuinal mode every
 longitudinal trajectory is combined with every lateral trajectory and transfromed
 back to world coordinates using the reference path. The trajectories are verified if they obey physical driving limits by
-subsequent point wise evaluation of curvature and acceleration. 
+subsequent point wise evaluation of curvature and acceleration.
 This leads to a set of potentially drivable maneuvers of a specific mode in world coordinates.
 5. **Static and dynamic collision check**
-Every trajectory set is evaluated with increasing total costs if static and dynamic 
+Every trajectory set is evaluated with increasing total costs if static and dynamic
 collisions are avoided. The trajectory with the lowest cost is then selected.
 6. **Longitudinal mode alternation**
 Using the sign based (in the beginning) jerk $\dot{a}(0)$, the trajectory with the
-strongest decceleration or the trajectory which accelerates the least respectively 
+strongest decceleration or the trajectory which accelerates the least respectively
 is selected and passed to the controller.
 
 # Frenet Coordinates
 
 "Frenet Coordinates", are a way of representing position on a road in a more intuitive way than traditional (x,y)
-Cartesian Coordinates. 
+Cartesian Coordinates.
 
-With Frenet coordinates, we use the variables s and d to describe a vehicle's position on the road or a reference path. 
+With Frenet coordinates, we use the variables s and d to describe a vehicle's position on the road or a reference path.
 The s coordinate represents distance along the road (also known as longitudinal displacement) and the d coordinate represents side-to-side position on the road (relative to the reference path), and is also known as lateral displacement.
 
 In the following sections the advantages and disadvantages of Frenet coordinates are compared to the Cartesian coordinates.
@@ -61,7 +61,7 @@ The image below depicts a curvy road with a Cartesian coordinate system laid on 
 
 <figure>
     <a href="https://raw.githubusercontent.com/fjp/frenet/master/docs/images/cart_refpath.svg?sanitize=true"><img src="https://raw.githubusercontent.com/fjp/frenet/master/docs/images/cart_refpath.svg?sanitize=true"></a>
-    <figcaption>Representation of a reference path (blue) in Cartesian coordinates (x,d).</figcaption>
+    <figcaption>Representation of a reference path (blue) in Cartesian coordinates (x,y).</figcaption>
 </figure>
 
 
@@ -73,13 +73,13 @@ The next image shows the same reference path together with its Frenet coordinate
 </figure>
 
 The s coordinate represents the run length and starts with s = 0 at the beginning of the reference path.
-Lateral positions relative to the reference path are are represented with the d coordinate. 
-Positions on the reference path are represented with d = 0. d is positive to the left of the reference path and 
+Lateral positions relative to the reference path are are represented with the d coordinate.
+Positions on the reference path are represented with d = 0. d is positive to the left of the reference path and
 negative on the right of it, although this depends on the convention used for the local reference frame.
 
 The image above shows that curved reference paths (such as curvy roads) are represented as straight lines on the
 s axis in Frenet coordinates. However, motions that do not follow the reference path exactly result in non straight
-motions in Frenet coordinates. Instead such motions result in an offset from the reference path and therefore the s axis, 
+motions in Frenet coordinates. Instead such motions result in an offset from the reference path and therefore the s axis,
 which is described with the d coordinate. The following image shows the two different representations (Cartesian vs Frenet).
 
 <figure>
@@ -87,14 +87,14 @@ which is described with the d coordinate. The following image shows the two diff
     <figcaption>Comparison of a planned trajectory in Cartesian and Frenet coordinates.</figcaption>
 </figure>
 
-To use Frenet coordinates it is required to have a continouosly smooth reference path. 
+To use Frenet coordinates it is required to have a continouosly smooth reference path.
 
 ### Reference Path
 
-Frenet coordinates provide a mathematically simpler representation of a reference path, 
+Frenet coordinates provide a mathematically simpler representation of a reference path,
 because its run length is described with the s axis. This reference path provides a rough reference
-to follow an arbitrary but curvature continuous course of the road. To avoid collisions, 
-the planner must take care of other objects in the environment, either static or dynamic. 
+to follow an arbitrary but curvature continuous course of the road. To avoid collisions,
+the planner must take care of other objects in the environment, either static or dynamic.
 Such objects are usually not avoided by the reference path.
 
 A reference path can be represented in two different forms although for all representations a run length information,
@@ -116,15 +116,10 @@ $$
 
 ### Transformation
 
-The transformation from local vehicle coordinates to Frenet coordinates is based on the relations shown in the following image:
+The transformation from local vehicle coordinates to Frenet coordinates is based on the following relations:
 
-<figure>
-    <a href="/assets/collections/fpv/frame-components.jpg"><img src="/assets/collections/fpv/frame-components.jpg"></a>
-    <figcaption>Transformation vehicle frame to Frenet frame.</figcaption>
-</figure>
-
-Given a point $P_C$ in the vehicle frame search for the closest point $R_C$ on the reference path. 
-The run length of $R_C$, which is known from the reference path points, 
+Given a point $P_C$ in the vehicle frame search for the closest point $R_C$ on the reference path.
+The run length of $R_C$, which is known from the reference path points,
 determins the s coordinate of the transformed point $P_F$.
 If the reference path is sufficiently smooth (continuously differentiable) then the vector $\vec{PR}$ is orthogonal
 to the reference path at the point $R_C$. The signed length of $\vec{PR}$ determines the d coordinate of $P_F$.
@@ -132,19 +127,18 @@ The sign is positive, if $P_C$ lies on the left along the run lenght of the refe
 
 The procedure to transform a point $P_F$ from Frenet coordinates to the local vehicle frame in Cartesian coordinates is analogous. First, the point $R_C$, which lies on the reference path at run length $s$. Next, a normal unit vector $\vec{d}$
 is determined, which, in this point, is orthogonal to the reference path. The direction of this vector points towards
-positive $d$ values and therefore points to the left with increasing run length $s$. 
+positive $d$ values and therefore points to the left with increasing run length $s$.
 Therefore, the vector $\vec{d}$ depends on the run length, which leads to:
 
 $$
 P_C(s,d) = R_C(s) + d \cdot \vec{d}(s)
 $$
 
-
 ## Usage
 
 ### Python Package
 
-The Python package uses [uv](https://docs.astral.sh/uv/) for dependency management. To get started:
+Python is the primary maintained implementation. It uses [uv](https://docs.astral.sh/uv/) for dependency management.
 
 ```bash
 cd python
@@ -169,19 +163,11 @@ x, y = frenet_to_cart(s=15.0, d=2.0, csp=csp)
 s, d = cart_to_frenet(px=15.0, py=3.0, csp=csp)
 ```
 
-#### Running Tests
+#### Jupyter Notebook
 
-```bash
-cd python
-uv sync --extra dev
-uv run pytest
-```
+In the `python/src/` folder you find a Jupyter Notebook which shows the described planning algorithm.
 
-### Jupyter Notebook
-
-In the python folder you find a Jupyter Notebook which shows the described planning algorithm.
-
-### Frenet GUI
+#### Frenet GUI
 
 Note: The Frenet GUI is not functional yet. Contributions are welcome. Here's the plan for this GUI:
 
@@ -198,6 +184,26 @@ To install the optional GUI dependency:
 cd python
 uv sync --extra gui
 ```
+
+### MATLAB
+
+The `matlab/` directory contains an equivalent MATLAB implementation of the Frenet-Cartesian transforms (`Cart2FRT.m`, `FRT2Cart.m`, `ClosestRefPoint.m`). Note that running the MATLAB code requires a MATLAB license.
+
+## Testing
+
+```bash
+cd python
+uv sync --extra dev
+uv run pytest
+```
+
+This runs the test suite in `python/tests/` which covers:
+
+- `frenet_to_cart` and `cart_to_frenet` transforms (straight and curved paths)
+- Round-trip consistency (Cartesian -> Frenet -> Cartesian)
+- Sign convention (d > 0 = left of path)
+- `quintic_polynomial` and `quartic_polynomial` boundary conditions
+- `Spline2D` arc length, position, and yaw
 
 ## References
 


### PR DESCRIPTION
## Summary
- Fix figure caption typo: (x,d) -> (x,y) for Cartesian coordinates
- Remove broken transformation image (frame-components.jpg 404)
- Add Python as primary implementation with uv setup instructions
- Add dedicated Testing section documenting pytest usage
- Add MATLAB section noting it requires a MATLAB license

## Test plan
- Review rendered README on GitHub for correct structure and working image links
